### PR TITLE
Handle segment gran changes

### DIFF
--- a/src/main/scala/com/metamx/tranquility/beam/BeamMaker.scala
+++ b/src/main/scala/com/metamx/tranquility/beam/BeamMaker.scala
@@ -16,6 +16,7 @@
  */
 package com.metamx.tranquility.beam
 
+import com.metamx.common.Granularity
 import com.metamx.common.scala.untyped._
 import org.scala_tools.time.Imports._
 
@@ -27,9 +28,9 @@ import org.scala_tools.time.Imports._
  */
 trait BeamMaker[A, BeamType <: Beam[A]]
 {
-  def newBeam(interval: Interval, partition: Int): BeamType
+  def newBeam(interval: Interval, partition: Int, granularity: Granularity, allowGranularityChange :Boolean): BeamType
 
   def toDict(beam: BeamType): Dict
 
-  def fromDict(d: Dict): BeamType
+  def fromDict(d: Dict, allowGranularityChanged :Boolean): BeamType
 }

--- a/src/main/scala/com/metamx/tranquility/beam/ClusteredBeam.scala
+++ b/src/main/scala/com/metamx/tranquility/beam/ClusteredBeam.scala
@@ -400,7 +400,7 @@ class ClusteredBeam[EventType: Timestamper, InnerBeamType <: Beam[EventType]](
           // It can be because of two reasons -
           //  1. Granularity has been decreased or
           //  2. The event belongs to a past interval which covers partial segment interval because the segment granularity was increased in middle of that new segment bucket
-          //     Basically it is a late event and can be dropped depending on the window period.
+          //     Basically it is a late event and might be dropped depending on the window period.
 
           allowGranularityChange = true
 

--- a/src/main/scala/com/metamx/tranquility/beam/ClusteredBeam.scala
+++ b/src/main/scala/com/metamx/tranquility/beam/ClusteredBeam.scala
@@ -218,8 +218,8 @@ class ClusteredBeam[EventType: Timestamper, InnerBeamType <: Beam[EventType]](
     val futureBeamOption = beams.get(timestamp.millis) match {
       case _ if !open => Future.value(None)
       // If the granularity has changed since tranquility restart and we found some beam that can handle this event return that beam
-      // In some scenarios the events may be dropped either by the client after retry (http timeout) if the task corresponding to beam is already finished
-      // or by Druid if the event is outside the window period (as this checks are performed in the next case - see below)
+      // In this scenario late event check (see next case) is not performed, thus the late events will be dropped either by the client after httpclient timeout if the task corresponding to beam is already finished
+      // or by Druid if the event is outside the window period (as this checks are performed in the next case - see below) and the task is still running
       // This case be further optimized by considering the actual granularity of the beam instead of tuning.segmentBucket to find out windowInterval
       // but more testing will be required and also we will need to store window period (and warming period) as well in ZK metadata to be accurate about when to drop events here
       case Some(x) if allowGranularityChange => {

--- a/src/main/scala/com/metamx/tranquility/druid/DruidBeam.scala
+++ b/src/main/scala/com/metamx/tranquility/druid/DruidBeam.scala
@@ -17,7 +17,7 @@
 package com.metamx.tranquility.druid
 
 import com.google.common.base.Charsets
-import com.metamx.common.Backoff
+import com.metamx.common.{Granularity, Backoff}
 import com.metamx.common.scala.Logging
 import com.metamx.common.scala.Predef._
 import com.metamx.common.scala.event.WARN
@@ -46,6 +46,7 @@ class DruidBeam[A : Timestamper](
   private[druid] val interval: Interval,
   private[druid] val partition: Int,
   private[druid] val tasks: Seq[DruidTaskPointer],
+  private[druid] val granularity: Option[Granularity], // It is an option as it may not be present for old ZK beam entries
   location: DruidLocation,
   config: DruidBeamConfig,
   finagleRegistry: FinagleRegistry,

--- a/src/test/scala/com/metamx/tranquility/test/ClusteredBeamTest.scala
+++ b/src/test/scala/com/metamx/tranquility/test/ClusteredBeamTest.scala
@@ -134,7 +134,7 @@ class ClusteredBeamTest extends FunSuite with CuratorRequiringSuite with BeforeA
 
   class TestingBeamMaker extends BeamMaker[SimpleEvent, TestingBeam]
   {
-    def newBeam(interval: Interval, partition: Int) = new TestingBeam(interval.start, partition)
+    def newBeam(interval: Interval, partition: Int, granularity: Granularity, allowGranularityChange :Boolean) = new TestingBeam(interval.start, partition)
 
     def toDict(beam: TestingBeam) = {
       Dict(
@@ -144,7 +144,7 @@ class ClusteredBeamTest extends FunSuite with CuratorRequiringSuite with BeforeA
       )
     }
 
-    def fromDict(d: Dict) = {
+    def fromDict(d: Dict, allowGranularityChange: Boolean) = {
       val timestamp = new DateTime(d("timestamp"))
       val partition = int(d("partition"))
       val uuid = str(d("uuid"))


### PR DESCRIPTION
With this PR tranquility can handle segment granularity changes without losing data and preventing hung up tasks. 
- If the granularity in decreased then new tasks with changed segment granularity will be not be spawned till the time existing task can handle the incoming events. For example, if at 10:12 the gran is changed from 5 Minutes to 1 Minute then till 10:15 no new tasks will be spawned.
- If the gran is increased then a partial beam (task having segment gran < the required segment gran) will be created to handle the events that falls in the interval not handled by currently active tasks for the new segment interval. For example, if the change is from 5 to 15 Minutes at 10:03 then a new task having interval 10:10 - 10:15 will be spawned to handle the incoming events.

During the time new events come in for tasks spawned to handle segment granularity changes, tranquility will not perform smart things like warming up beams, performing strict checking on interval while constructing beam object from the dictionary etc.
